### PR TITLE
Feature/config jzon

### DIFF
--- a/ImageTrimmingTool/App/TrimConfig.cs
+++ b/ImageTrimmingTool/App/TrimConfig.cs
@@ -28,12 +28,20 @@ namespace ImageTrimmingTool.App
             foreach ( var itor in map )
             {
                 string name = itor.Key;    // パラメータファイルの識別名
-                string file = itor.Value;  // パラメータファイルのパス
+                string text = itor.Value;  // パラメータファイルのパス
 
                 // 指定されたパラメータファイルがあればJSON定義を読み込む。
-                if ( File.Exists( file ) )
-                { 
-                    string json = File.ReadAllText( file ).fuzzy();
+                if ( File.Exists( text ) )
+                {
+                    string json = File.ReadAllText( text ).fuzzy();
+                    var parameter = TrimParameterJSON.Parse( json );
+
+                    this.Add( name, parameter );
+                }
+                // ファイルが存在しなかった場合 JZON リテラルとしてパースしてみる。
+                else
+                {
+                    string json = text.fuzzy();
                     var parameter = TrimParameterJSON.Parse( json );
 
                     this.Add( name, parameter );

--- a/ImageTrimmingTool/App/TrimConfig.cs
+++ b/ImageTrimmingTool/App/TrimConfig.cs
@@ -27,24 +27,22 @@ namespace ImageTrimmingTool.App
             var map = this.Read( path );
             foreach ( var itor in map )
             {
-                string name = itor.Key;    // パラメータファイルの識別名
-                string text = itor.Value;  // パラメータファイルのパス
+                string name = itor.Key;    // パラメータの識別名
+                string text = itor.Value;  // パラメータの定義ファイルパス、若しくは JZON直値
 
-                // 指定されたパラメータファイルがあればJSON定義を読み込む。
-                if ( File.Exists( text ) )
+                // 指定されたパラメータファイルがあれば JSON定義 を読み込む。
+                // ファイルが存在しなかった場合 JZONリテラル としてパースしてみる。
+                string jzon = File.Exists( text )
+                    ? File.ReadAllText( text ).fuzzy()
+                    : text.fuzzy();
+                try
                 {
-                    string json = File.ReadAllText( text ).fuzzy();
-                    var parameter = TrimParameterJSON.Parse( json );
-
+                    var parameter = TrimParameterJSON.Parse( jzon );
                     this.Add( name, parameter );
                 }
-                // ファイルが存在しなかった場合 JZON リテラルとしてパースしてみる。
-                else
+                catch ( Exception )
                 {
-                    string json = text.fuzzy();
-                    var parameter = TrimParameterJSON.Parse( json );
-
-                    this.Add( name, parameter );
+                    // ignore
                 }
             }
 


### PR DESCRIPTION
起動時に読み込む定義済パラメータの指定方法がファイルパス指定だけだったので
ファイルが存在しなかった場合はJZONリテラルとして扱うルートを追加。